### PR TITLE
Fixed stacks of more than one fluid cell. (#29, #30)

### DIFF
--- a/src/main/java/me/towdium/jecalculation/data/label/ILabel.java
+++ b/src/main/java/me/towdium/jecalculation/data/label/ILabel.java
@@ -284,6 +284,7 @@ public interface ILabel {
                 if (isGregTechLargeFluidContainer(itemStack)) {
                     FluidStack fluidStack = GTUtility.getFluidForFilledItem(itemStack, true);
                     if (fluidStack != null) {
+                        fluidStack.amount = fluidStack.amount * itemStack.stackSize;
                         return new LFluidStack(fluidStack);
                     }
                 }


### PR DESCRIPTION
Fixes #29, fixes #30.

It's not clear to me whether the fix belongs in here or in `GTUtility`. It works, I just don't know if the `GTUtility` code is wrong and other (undiscovered?) bugs would be fixed by changing it instead. Also, if later on a multiplication is added to the `GTUtility` code, then we'll end up with a "double multiply" bug.

btw, I couldn't get `./gradlew runClient` to work without adding `compile("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.33:dev")` to `build.gradle`. (it crashes with `NoClassDefError` on `GTUtility` without the addition). I'm not familiar with the intricacies of class loading in modded minecraft, but I assume it's omitted for a reason, so I left it out here.