### PR TITLE
Allow FindIt 'Find item in nearby inventory' key

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,6 +4,7 @@ dependencies {
 //    compile("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-527-GTNH:dev")
     compile("com.github.GTNewHorizons:CodeChickenCore:1.4.1:dev")
     compile("com.github.GTNewHorizons:NotEnoughItems:2.7.23-GTNH:dev")
+    compile("com.github.GTNewHorizons:FindIt:1.3.10:dev")
 //    compile("com.github.GTNewHorizons:Baubles:1.0.4:dev")
 //    compile("com.github.GTNewHorizons:WirelessCraftingTerminal:1.11.7:dev")
 

--- a/src/main/java/me/towdium/jecalculation/event/handlers/NEIEventHandler.java
+++ b/src/main/java/me/towdium/jecalculation/event/handlers/NEIEventHandler.java
@@ -15,6 +15,8 @@ import me.towdium.jecalculation.nei.NEIPlugin;
 
 public class NEIEventHandler implements IContainerInputHandler {
 
+    private static final boolean isFindItLoaded = Loader.isModLoaded("findit");
+
     @Override
     public boolean keyTyped(GuiContainer guiContainer, char c, int i) {
         return false;
@@ -42,7 +44,7 @@ public class NEIEventHandler implements IContainerInputHandler {
             if (keyCode == NEIClientConfig.getKeyBinding("gui.recipe")) {
                 return NEIPlugin.openRecipeGui(stack, false);
             }
-            if (Loader.isModLoaded("findit")) {
+            if (isFindItLoaded) {
                 if (keyCode == NEIClientConfig.getKeyBinding(getFindItKeyBind())) {
                     return NEIPlugin.findItem(stack);
                 }

--- a/src/main/java/me/towdium/jecalculation/event/handlers/NEIEventHandler.java
+++ b/src/main/java/me/towdium/jecalculation/event/handlers/NEIEventHandler.java
@@ -3,9 +3,12 @@ package me.towdium.jecalculation.event.handlers;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.inventory.GuiContainer;
 
+import com.gtnh.findit.FindIt;
+
 import codechicken.nei.NEIClientConfig;
 import codechicken.nei.NEIClientUtils;
 import codechicken.nei.guihook.IContainerInputHandler;
+import cpw.mods.fml.common.Loader;
 import me.towdium.jecalculation.data.label.ILabel;
 import me.towdium.jecalculation.gui.JecaGui;
 import me.towdium.jecalculation.nei.NEIPlugin;
@@ -19,6 +22,10 @@ public class NEIEventHandler implements IContainerInputHandler {
 
     @Override
     public void onKeyTyped(GuiContainer guiContainer, char c, int i) {}
+
+    protected String getFindItKeyBind() {
+        return FindIt.isExtraUtilitiesLoaded() ? "gui.xu_ping" : "gui.findit.find_item";
+    }
 
     @Override
     public boolean lastKeyTyped(GuiContainer guiContainer, char keyChar, int keyCode) {
@@ -34,6 +41,11 @@ public class NEIEventHandler implements IContainerInputHandler {
             }
             if (keyCode == NEIClientConfig.getKeyBinding("gui.recipe")) {
                 return NEIPlugin.openRecipeGui(stack, false);
+            }
+            if (Loader.isModLoaded("findit")) {
+                if (keyCode == NEIClientConfig.getKeyBinding(getFindItKeyBind())) {
+                    return NEIPlugin.findItem(stack);
+                }
             }
 
             return false;

--- a/src/main/java/me/towdium/jecalculation/nei/NEIPlugin.java
+++ b/src/main/java/me/towdium/jecalculation/nei/NEIPlugin.java
@@ -5,6 +5,9 @@ import java.lang.reflect.Method;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
+import com.gtnh.findit.FindItNetwork;
+import com.gtnh.findit.service.itemfinder.FindItemRequest;
+
 import codechicken.nei.guihook.GuiContainerManager;
 import codechicken.nei.recipe.GuiCraftingRecipe;
 import codechicken.nei.recipe.GuiUsageRecipe;
@@ -106,4 +109,19 @@ public class NEIPlugin {
         }
         return false;
     }
+
+    public static boolean findItem(Object rep) {
+        if (rep instanceof FluidStack) {
+            ItemStack itemStack = FluidStackToItemStack.getItemStack((FluidStack) rep);
+            if (itemStack != null) {
+                rep = itemStack;
+            }
+        }
+        if (rep instanceof ItemStack) {
+            FindItNetwork.CHANNEL.sendToServer(new FindItemRequest((ItemStack) rep));
+
+        }
+        return true;
+    }
+
 }


### PR DESCRIPTION
Allows the use of the 'Find item in nearby inventory' key when mousing over items/steps in JustEnoughCalculation.